### PR TITLE
Flexible header and input

### DIFF
--- a/R/run_coloc.R
+++ b/R/run_coloc.R
@@ -1,9 +1,10 @@
 
-## todo
+## todos
+## - tests for beta/sebeta
 ## - warnings
-## - error out if header incomplete
+##      - error out if header incomplete
 ## - finetune parameters
-## - coloc.abf correct?
+## - function coloc.abf correct?
 ## - locuszoomplot
 
 #' @param eqtl_data input file path, ftp or local

--- a/tests/testthat/test-run_coloc.R
+++ b/tests/testthat/test-run_coloc.R
@@ -1,28 +1,59 @@
 
-test_that("Coloc for region on chr 1 between Lepik blood and FG I9_VARICVE for gene ENSG00000130940", {
+test_that("MAF + PVAL: Coloc for region on chr 1 between Lepik blood and FG I9_VARICVE for gene ENSG00000130940", {
 
   reference <- readRDS("../rds/lepik_I9_VARICVE_chr1_ENSG00000130940.rds")
 
-  dat_single <- run_coloc(eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000130940.all.tsv", gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", return_object = TRUE)
+  dat_single <- run_coloc(
+    eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000130940.all.tsv", 
+    gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", 
+    return_object = TRUE, return_file = FALSE,
+    eqtl_info = list(type = "quant", sdY = 1, N = 491), 
+    gwas_info = list(type = "cc", s = 11006/117692, N  = 11006	+ 117692), 
+    gwas_header = c(varid = "rsids", pvalues = "pval", MAF = "maf"), 
+    eqtl_header = c(varid = "rsid", pvalues = "pvalue", MAF = "maf", gene_id = "gene_id")
+   )
   expect_equal(dat_single, reference)
 
-  dat <- run_coloc(eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655_ENSG00000130940.all.tsv", gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", return_object = TRUE)
+  dat <- run_coloc(
+    eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655_ENSG00000130940.all.tsv", 
+    gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", 
+    return_object = TRUE, return_file = FALSE,
+    eqtl_info = list(type = "quant", sdY = 1, N = 491), 
+    gwas_info = list(type = "cc", s = 11006/117692, N  = 11006	+ 117692), 
+    gwas_header = c(varid = "rsids", pvalues = "pval", MAF = "maf"), 
+    eqtl_header = c(varid = "rsid", pvalues = "pvalue", MAF = "maf", gene_id = "gene_id")
+   )
   expect_equal(data.frame(droplevels(dat[dat$gene == "ENSG00000130940",]), row.names = NULL), reference)
 
 })
 
 
-test_that("Coloc for region on chr 1 between Lepik blood and FG I9_VARICVE for gene ENSG00000142655", {
+test_that("MAF + PVAL: Coloc for region on chr 1 between Lepik blood and FG I9_VARICVE for gene ENSG00000142655", {
   
   reference <- readRDS("../rds/lepik_I9_VARICVE_chr1_ENSG00000142655.rds")
 
-  dat_single <- run_coloc(eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655.all.tsv", gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", 
-    return_object = TRUE, return_file = FALSE)
+  dat_single <- run_coloc(
+    eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655.all.tsv", 
+    gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", 
+    return_object = TRUE, return_file = FALSE,
+    eqtl_info = list(type = "quant", sdY = 1, N = 491), 
+    gwas_info = list(type = "cc", s = 11006/117692, N  = 11006	+ 117692), 
+    gwas_header = c(varid = "rsids", pvalues = "pval", MAF = "maf"), 
+    eqtl_header = c(varid = "rsid", pvalues = "pvalue", MAF = "maf", gene_id = "gene_id")
+   )
   expect_equal(dat_single, reference)
 
-  dat <- run_coloc(eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655_ENSG00000130940.all.tsv", gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz", 
-      return_object = TRUE, return_file = FALSE)
-
+  dat <- run_coloc(
+    eqtl_data = "../../extdata/Lepik_2017_ge_blood_chr1_ENSG00000142655_ENSG00000130940.all.tsv", 
+    gwas_data = "../../extdata/I9_VARICVE_chr1.tsv.gz",
+    return_object = TRUE, return_file = FALSE,
+    eqtl_info = list(type = "quant", sdY = 1, N = 491), 
+    gwas_info = list(type = "cc", s = 11006/117692, N  = 11006	+ 117692), 
+    gwas_header = c(varid = "rsids", pvalues = "pval", MAF = "maf"), 
+    eqtl_header = c(varid = "rsid", pvalues = "pvalue", MAF = "maf", gene_id = "gene_id")
+   )
   expect_equal(data.frame(droplevels(dat[dat$gene == "ENSG00000142655",]), row.names = NULL), reference)
 
 })
+
+##     gwas_header = c(varid = "rsids", MAF = "maf", beta = "beta", sebeta = "sebeta"),


### PR DESCRIPTION
- new function arguments `eqtl_info`, `eqtl_header` and `gwas_info`, `gwas_header` so inputformat can be whatever
- data headers are now automatically standardized after import
- coloc.abf will complain if input data is missing