### PR TITLE
fix locuscompare size

### DIFF
--- a/R/run_coloc.R
+++ b/R/run_coloc.R
@@ -31,14 +31,8 @@ locuscompare <- function(df, gene, filename) {
         stop("eQTL pvalue column is needed for the locuscompare plot, but missing from the data.")
     }
 
-    if (max(-log10(df$pvalues.gwas)) < max(-log10(df$pvalues.eqtl))) { # ratio for the plot coordinates 
-        ratio <- (max(-log10(df$pvalues.eqtl))) / (max(-log10(df$pvalues.gwas)))
-    }
-    else {
-        ratio <- (max(-log10(df$pvalues.gwas))) / (max(-log10(df$pvalues.eqtl)))
-    }
     plot <- ggplot2::ggplot(data = df, aes(x = -log10(pvalues.gwas), y = -log10(pvalues.eqtl))) + geom_point(size = 0.6) + geom_abline(color = "black", linetype = 3) + 
-        geom_smooth(method = "lm", se = FALSE, color = "black", size = 0.5) + theme_light() + coord_fixed(ratio = ratio) +
+        geom_smooth(method = "lm", se = FALSE, color = "black", size = 0.5) + theme_light() + coord_fixed(ratio = 1) +
         labs(title = paste0(filename, " - ", gene), x = "GWAS -log10(P)", y = "eQTL -log10(P)") + 
         theme(axis.text.x = element_text(size = 7), axis.text.y = element_text(size = 7), axis.text = element_text(size = 7), plot.title = element_text(size = 12))
     


### PR DESCRIPTION
The ratio of the y and x axis are computed based on their ranges.

This works well, when x and y have similar ranges,

![I9_VARICVE-BLUEPRINT_ge_T-cell-19_13332412_19332412_locuscompare_ENSG00000130520](https://user-images.githubusercontent.com/4454726/97776896-b57daa00-1b74-11eb-8b8b-3b882b459494.png)
 but can become an unreadable plot when x and y have very different maximum values. 
![I9_VARICVE-BLUEPRINT_ge_T-cell-19_13332412_19332412_locuscompare_ENSG00000127528](https://user-images.githubusercontent.com/4454726/97776893-aeef3280-1b74-11eb-91b5-f52511d72207.png)

Using proportional axis width to the actual values is good practice, but in this case impractical. 
In my opinion, because we mark the identity line, its ok to set the ratio to 1.